### PR TITLE
category map generation fix

### DIFF
--- a/src/WL/AppBundle/Resources/views/MapCategory/index.html.twig
+++ b/src/WL/AppBundle/Resources/views/MapCategory/index.html.twig
@@ -30,7 +30,7 @@
 
                 <div class="col-xs-12">
 
-                    {% for menuLink in menu_main %}
+                    {% for menuLink in menu_main.menuLinks %}
                         <div>
                             <h3>{{ menuLink.name }}</h3>
                             <ul>


### PR DESCRIPTION
Brakowało iteracji po menuLinks, przez co mapa kategorii była zawsze pusta.